### PR TITLE
onclickイベントハンドラでsubmitしていた処理、windowのイベントとして設定されていたので、

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,12 +54,12 @@
   function keydown(e){
       if(e.keyCode === 13){
         var obj = document.activeElement;
-        //console.log(obj); リセットボタンが消失することが原因でエラーを吐いている気がする。現段階では操作上問題はないのでそのまま。
+        console.log(obj);
         obj.nextElementSibling.focus();
       }
     }
     
-  window.onkeydown = keydown;
+  guessField.onkeydown = keydown;
 
   var guessCount = 1;
   var resetButton;


### PR DESCRIPTION
input(text)のイベントとして設定し直した
　⇒　Enterキー押下時にエラーが起こらなくなる。